### PR TITLE
Make units configurable

### DIFF
--- a/src/Commands/FetchOpenWeatherMapDataCommand.php
+++ b/src/Commands/FetchOpenWeatherMapDataCommand.php
@@ -17,6 +17,7 @@ class FetchOpenWeatherMapDataCommand extends Command
         $weatherReport = OpenWeatherMap::getWeatherReport(
             config('dashboard.tiles.time_weather.open_weather_map_key'),
             config('dashboard.tiles.time_weather.open_weather_map_city'),
+            config('dashboard.tiles.time_weather.units'),
         );
 
         TimeWeatherStore::make()->setWeatherReport($weatherReport);

--- a/src/Commands/FetchOpenWeatherMapDataCommand.php
+++ b/src/Commands/FetchOpenWeatherMapDataCommand.php
@@ -17,7 +17,7 @@ class FetchOpenWeatherMapDataCommand extends Command
         $weatherReport = OpenWeatherMap::getWeatherReport(
             config('dashboard.tiles.time_weather.open_weather_map_key'),
             config('dashboard.tiles.time_weather.open_weather_map_city'),
-            config('dashboard.tiles.time_weather.units'),
+            config('dashboard.tiles.time_weather.units') ?? 'metric',
         );
 
         TimeWeatherStore::make()->setWeatherReport($weatherReport);

--- a/src/Services/OpenWeatherMap.php
+++ b/src/Services/OpenWeatherMap.php
@@ -8,7 +8,7 @@ class OpenWeatherMap
 {
     public static function getWeatherReport(string $key, string $city, string $units): array
     {
-        $url = "https://api.openweathermap.org/data/2.5/weather?q={$city}&appid={$key}&units={$key}";
+        $url = "https://api.openweathermap.org/data/2.5/weather?q={$city}&appid={$key}&units={$units}";
 
         return Http::get($url)->json();
     }

--- a/src/Services/OpenWeatherMap.php
+++ b/src/Services/OpenWeatherMap.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Facades\Http;
 
 class OpenWeatherMap
 {
-    public static function getWeatherReport(string $key, string $city): array
+    public static function getWeatherReport(string $key, string $city, string $units): array
     {
-        $url = "https://api.openweathermap.org/data/2.5/weather?q={$city}&appid={$key}&units=metric";
+        $url = "https://api.openweathermap.org/data/2.5/weather?q={$city}&appid={$key}&units={$key}";
 
         return Http::get($url)->json();
     }


### PR DESCRIPTION
This PR allows the user to optionally define the unit type to be used in the OpenWeatherMap API call. By default, if no config is set, `metric` will be used.

Unit options are `metric` and `imperial`

```
'tiles' => [
    'time_weather' => [
        'open_weather_map_key' => env('OPEN_WEATHER_MAP_KEY'),
        'open_weather_map_city' => 'Omaha',
        'units' => 'imperial',
        'buienradar_latitude' => env('BUIENRADAR_LATITUDE'),
        'buienradar_longitude' => env('BUIENRADAR_LONGITUDE'),
    ],
],
```