### PR TITLE
Update tile.blade.php

### DIFF
--- a/resources/views/tile.blade.php
+++ b/resources/views/tile.blade.php
@@ -30,7 +30,7 @@
                 <div
                     class="rounded-sm bg-accent"
                     style="height:{{ $forecast['rain'] * 100 }}%"
-                />
+                ></div>
             @endforeach
         </div>
     </div>


### PR DESCRIPTION
Using the `<div />` doesn't close the `<div>`-tag properly in some browsers, resulting in a full-screen time-weather-tile.

Code:
```
<x-dashboard>
    <livewire:time-weather-tile position="a1" />
    <livewire:packagist-tile position="a2:a3" />
</x-dashboard>
```

Result:  
![image](https://user-images.githubusercontent.com/27762458/85553515-51763280-b624-11ea-8543-af3729b6ced0.png)