### PR TITLE
Fix clock to use configured timezone

### DIFF
--- a/resources/views/tile.blade.php
+++ b/resources/views/tile.blade.php
@@ -41,6 +41,7 @@
         function clock() {
             return {
                 dateTime: new Date(),
+                timezone: '{{ config('dashboard.tiles.time_weather.timezone', 'Europe/Brussels') }}',
 
                 tick() {
                     setInterval(() => {
@@ -50,22 +51,25 @@
 
                 get date() {
                     const day = this.dateTime
-                        .toLocaleDateString('{{ app()->getLocale() }}', { weekday: 'long' })
+                        .toLocaleDateString('{{ app()->getLocale() }}', { weekday: 'long', timeZone: this.timezone })
                         .substr(0, 3);
 
-                    const date = [
-                        this.dateTime.getDate(),
-                        this.dateTime.getMonth() + 1,
-                    ].map(this.padNumber).join('/');
+                    const dateNum = this.dateTime.toLocaleDateString('en-GB', {
+                        day: '2-digit',
+                        month: '2-digit',
+                        timeZone: this.timezone,
+                    });
 
-                    return `${day} ${date}`;
+                    return `${day} ${dateNum}`;
                 },
 
                 get time() {
-                    return [
-                        this.dateTime.getHours(),
-                        this.dateTime.getMinutes(),
-                    ].map(this.padNumber).join(':');
+                    return this.dateTime.toLocaleTimeString('{{ app()->getLocale() }}', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        hour12: false,
+                        timeZone: this.timezone,
+                    });
                 },
 
                 padNumber(number) {


### PR DESCRIPTION
## Summary

- The clock was using the browser's local timezone via `new Date()` getters (`getHours`, `getMinutes`, etc.)
- Now reads timezone from `config('dashboard.tiles.time_weather.timezone')` and uses `toLocaleTimeString`/`toLocaleDateString` with the `timeZone` option
- Falls back to `Europe/Brussels` if no timezone is configured
- Corresponds to spatie/dashboard.spatie.be#183

## Why

Every time daylight saving time kicks in (summer/winter time), the Raspberry Pi's system clock would show the wrong time on the dashboard, requiring an SSH session to manually fix it. By using an IANA timezone (e.g. `Europe/Brussels`) instead of relying on the system clock's local time, JavaScript handles DST transitions automatically. No more SSHing into the Pi twice a year.